### PR TITLE
kata go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,7 @@ compile_commands.json
 *.txt
 .env
 .pnpm-store/
+
+# golang
+!go.mod
+!go.sum

--- a/kata/bowling_game/go/2023_12-31/bowling_game.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game.go
@@ -20,17 +20,21 @@ func (g *Game) Roll(pins int) {
 
 func (g *Game) Score() int {
 	score := 0
-	i := 0
+	frameIndex := 0
 	for frame := 0; frame < 10; frame++ {
-		if g.rolls[i]+g.rolls[i+1] == 10 {
-			score += 10 + g.rolls[i+2]
-			i += 2
+		if g.isSpare(frameIndex) {
+			score += 10 + g.rolls[frameIndex+2]
+			frameIndex += 2
 		} else {
-			score += g.rolls[i] + g.rolls[i+1]
-			i += 2
+			score += g.rolls[frameIndex] + g.rolls[frameIndex+1]
+			frameIndex += 2
 
 		}
 	}
 
 	return score
+}
+
+func (g *Game) isSpare(frameIndex int) bool {
+	return g.rolls[frameIndex]+g.rolls[frameIndex+1] == 10
 }

--- a/kata/bowling_game/go/2023_12-31/bowling_game.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game.go
@@ -21,14 +21,18 @@ func (g *Game) Roll(pins int) {
 func (g *Game) Score() int {
 	score := 0
 	frameIndex := 0
+
 	for frame := 0; frame < 10; frame++ {
-		if g.isSpare(frameIndex) {
+		if g.rolls[frameIndex] == 10 {
+			// strike
+			score += 10 + g.rolls[frameIndex+1] + g.rolls[frameIndex+2]
+			frameIndex++
+		} else if g.isSpare(frameIndex) {
 			score += 10 + g.rolls[frameIndex+2]
 			frameIndex += 2
 		} else {
 			score += g.rolls[frameIndex] + g.rolls[frameIndex+1]
 			frameIndex += 2
-
 		}
 	}
 

--- a/kata/bowling_game/go/2023_12-31/bowling_game.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game.go
@@ -1,17 +1,36 @@
 package bowling
 
 type Game struct {
-	score int
+	score       int
+	rolls       [21]int
+	currentRole int
 }
 
 func NewGame() *Game {
-	return &Game{score: 0}
+	return &Game{
+		score:       0,
+		currentRole: 0,
+	}
 }
 
 func (g *Game) Roll(pins int) {
-	g.score += pins
+	g.rolls[g.currentRole] = pins
+	g.currentRole++
 }
 
 func (g *Game) Score() int {
-	return g.score
+	score := 0
+	i := 0
+	for frame := 0; frame < 10; frame++ {
+		if g.rolls[i]+g.rolls[i+1] == 10 {
+			score += 10 + g.rolls[i+2]
+			i += 2
+		} else {
+			score += g.rolls[i] + g.rolls[i+1]
+			i += 2
+
+		}
+	}
+
+	return score
 }

--- a/kata/bowling_game/go/2023_12-31/bowling_game.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game.go
@@ -1,5 +1,7 @@
 package bowling
 
+import "fmt"
+
 type Game struct {
 	score       int
 	rolls       [21]int
@@ -13,9 +15,14 @@ func NewGame() *Game {
 	}
 }
 
-func (g *Game) Roll(pins int) {
+func (g *Game) Roll(pins int) error {
+	if pins < 0 || 10 < pins {
+		return fmt.Errorf("Invalid number of pins: %d", pins)
+	}
+
 	g.rolls[g.currentRoll] = pins
 	g.currentRoll++
+	return nil
 }
 
 func (g *Game) Score() int {

--- a/kata/bowling_game/go/2023_12-31/bowling_game.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game.go
@@ -23,15 +23,14 @@ func (g *Game) Score() int {
 	frameIndex := 0
 
 	for frame := 0; frame < 10; frame++ {
-		if g.rolls[frameIndex] == 10 {
-			// strike
-			score += 10 + g.rolls[frameIndex+1] + g.rolls[frameIndex+2]
+		if g.isStrike(frameIndex) {
+			score += g.strikeBonus(frameIndex)
 			frameIndex++
 		} else if g.isSpare(frameIndex) {
-			score += 10 + g.rolls[frameIndex+2]
+			score += g.spareBonus(frameIndex)
 			frameIndex += 2
 		} else {
-			score += g.rolls[frameIndex] + g.rolls[frameIndex+1]
+			score += g.sumOfBallsInFrame(frameIndex)
 			frameIndex += 2
 		}
 	}
@@ -39,6 +38,22 @@ func (g *Game) Score() int {
 	return score
 }
 
+func (g *Game) isStrike(frameIndex int) bool {
+	return g.rolls[frameIndex] == 10
+}
+
 func (g *Game) isSpare(frameIndex int) bool {
 	return g.rolls[frameIndex]+g.rolls[frameIndex+1] == 10
+}
+
+func (g *Game) sumOfBallsInFrame(frameIndex int) int {
+	return g.rolls[frameIndex] + g.rolls[frameIndex+1]
+}
+
+func (g *Game) spareBonus(frameIndex int) int {
+	return 10 + g.rolls[frameIndex+2]
+}
+
+func (g *Game) strikeBonus(frameIndex int) int {
+	return 10 + g.rolls[frameIndex+1] + g.rolls[frameIndex+2]
 }

--- a/kata/bowling_game/go/2023_12-31/bowling_game.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game.go
@@ -3,19 +3,19 @@ package bowling
 type Game struct {
 	score       int
 	rolls       [21]int
-	currentRole int
+	currentRoll int
 }
 
 func NewGame() *Game {
 	return &Game{
 		score:       0,
-		currentRole: 0,
+		currentRoll: 0,
 	}
 }
 
 func (g *Game) Roll(pins int) {
-	g.rolls[g.currentRole] = pins
-	g.currentRole++
+	g.rolls[g.currentRoll] = pins
+	g.currentRoll++
 }
 
 func (g *Game) Score() int {

--- a/kata/bowling_game/go/2023_12-31/bowling_game.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game.go
@@ -1,15 +1,17 @@
 package bowling
 
-type Game struct{}
+type Game struct {
+	score int
+}
 
 func NewGame() *Game {
-	return &Game{}
+	return &Game{score: 0}
 }
 
 func (g *Game) Roll(pins int) {
-
+	g.score += pins
 }
 
 func (g *Game) Score() int {
-	return 0
+	return g.score
 }

--- a/kata/bowling_game/go/2023_12-31/bowling_game.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game.go
@@ -1,0 +1,15 @@
+package bowling
+
+type Game struct{}
+
+func NewGame() *Game {
+	return &Game{}
+}
+
+func (g *Game) Roll(pins int) {
+
+}
+
+func (g *Game) Score() int {
+	return 0
+}

--- a/kata/bowling_game/go/2023_12-31/bowling_game_test.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game_test.go
@@ -26,6 +26,10 @@ func rollDifferentSpare() {
 	g.Roll(6)
 }
 
+func rollStrike() {
+	g.Roll(10)
+}
+
 func TestGutterGame(t *testing.T) {
 	setUp()
 
@@ -70,7 +74,7 @@ func TestDifferentPinsSpare(t *testing.T) {
 func TestOneStrike(t *testing.T) {
 	setUp()
 
-	g.Roll(10) // strike
+	rollStrike()
 	g.Roll(3)
 	g.Roll(4)
 	rollMany(16, 0)

--- a/kata/bowling_game/go/2023_12-31/bowling_game_test.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game_test.go
@@ -34,11 +34,24 @@ func TestAllOnes(t *testing.T) {
 	}
 }
 
-func TestOneSpare(t *testing.T) {
+func TestStandardSpare(t *testing.T) {
 	setUp()
 
 	g.Roll(5)
 	g.Roll(5) // spare
+	g.Roll(3)
+	rollMany(17, 0)
+
+	if g.Score() != 16 {
+		t.Errorf("Expected score of 16 but got %d", g.Score())
+	}
+}
+
+func TestDifferentPinsSpare(t *testing.T) {
+	setUp()
+
+	g.Roll(4)
+	g.Roll(6) // spare
 	g.Roll(3)
 	rollMany(17, 0)
 

--- a/kata/bowling_game/go/2023_12-31/bowling_game_test.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game_test.go
@@ -83,3 +83,13 @@ func TestOneStrike(t *testing.T) {
 		t.Errorf("Expected score of 24 but got %d", g.Score())
 	}
 }
+
+func TestPerfectGame(t *testing.T) {
+	setUp()
+
+	rollMany(12, 10)
+
+	if g.Score() != 300 {
+		t.Errorf("Expected score of 300 but got %d", g.Score())
+	}
+}

--- a/kata/bowling_game/go/2023_12-31/bowling_game_test.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game_test.go
@@ -93,3 +93,17 @@ func TestPerfectGame(t *testing.T) {
 		t.Errorf("Expected score of 300 but got %d", g.Score())
 	}
 }
+
+func TestRollInvalidPins(t *testing.T) {
+	setUp()
+
+	err := g.Roll(-1)
+	if err == nil {
+		t.Errorf("Expected an error for invalid pins, but got none")
+	}
+
+	expectedErrorMessage := "Invalid number of pins: -1"
+	if err.Error() != expectedErrorMessage {
+		t.Errorf("Unexpected error message: got %v want %v", err.Error(), expectedErrorMessage)
+	}
+}

--- a/kata/bowling_game/go/2023_12-31/bowling_game_test.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game_test.go
@@ -66,3 +66,16 @@ func TestDifferentPinsSpare(t *testing.T) {
 		t.Errorf("Expected score of 16 but got %d", g.Score())
 	}
 }
+
+func TestOneStrike(t *testing.T) {
+	setUp()
+
+	g.Roll(10) // strike
+	g.Roll(3)
+	g.Roll(4)
+	rollMany(16, 0)
+
+	if g.Score() != 24 {
+		t.Errorf("Expected score of 24 but got %d", g.Score())
+	}
+}

--- a/kata/bowling_game/go/2023_12-31/bowling_game_test.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game_test.go
@@ -1,7 +1,6 @@
 package bowling
 
 import (
-	"os"
 	"testing"
 )
 
@@ -17,13 +16,9 @@ func rollMany(n int, pins int) {
 	}
 }
 
-func TestMain(m *testing.M) {
+func TestGutterGame(t *testing.T) {
 	setUp()
 
-	os.Exit(m.Run())
-}
-
-func TestGutterGame(t *testing.T) {
 	rollMany(20, 0)
 	if g.Score() != 0 {
 		t.Errorf("Expected score of 0 but got %d", g.Score())
@@ -31,9 +26,23 @@ func TestGutterGame(t *testing.T) {
 }
 
 func TestAllOnes(t *testing.T) {
+	setUp()
 	rollMany(20, 1)
 
 	if g.Score() != 20 {
 		t.Errorf("Expected score of 20 but got %d", g.Score())
+	}
+}
+
+func TestOneSpare(t *testing.T) {
+	setUp()
+
+	g.Roll(5)
+	g.Roll(5) // spare
+	g.Roll(3)
+	rollMany(17, 0)
+
+	if g.Score() != 16 {
+		t.Errorf("Expected score of 16 but got %d", g.Score())
 	}
 }

--- a/kata/bowling_game/go/2023_12-31/bowling_game_test.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game_test.go
@@ -16,6 +16,16 @@ func rollMany(n int, pins int) {
 	}
 }
 
+func rollStandardSpare() {
+	g.Roll(5)
+	g.Roll(5)
+}
+
+func rollDifferentSpare() {
+	g.Roll(4)
+	g.Roll(6)
+}
+
 func TestGutterGame(t *testing.T) {
 	setUp()
 
@@ -36,9 +46,7 @@ func TestAllOnes(t *testing.T) {
 
 func TestStandardSpare(t *testing.T) {
 	setUp()
-
-	g.Roll(5)
-	g.Roll(5) // spare
+	rollStandardSpare()
 	g.Roll(3)
 	rollMany(17, 0)
 
@@ -50,8 +58,7 @@ func TestStandardSpare(t *testing.T) {
 func TestDifferentPinsSpare(t *testing.T) {
 	setUp()
 
-	g.Roll(4)
-	g.Roll(6) // spare
+	rollDifferentSpare()
 	g.Roll(3)
 	rollMany(17, 0)
 

--- a/kata/bowling_game/go/2023_12-31/bowling_game_test.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game_test.go
@@ -1,23 +1,38 @@
 package bowling
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
+
+var g *Game
+
+func setUp() {
+	g = NewGame()
+}
+
+func TestMain(m *testing.M) {
+	setUp()
+
+	os.Exit(m.Run())
+}
 
 func TestGutterGame(t *testing.T) {
-	game := NewGame()
 	for i := 0; i < 20; i++ {
-		game.Roll(0)
+		g.Roll(0)
 	}
-	if game.Score() != 0 {
-		t.Errorf("Expected score of 0 but got %d", game.Score())
+
+	if g.Score() != 0 {
+		t.Errorf("Expected score of 0 but got %d", g.Score())
 	}
 }
 
 func TestAllOnes(t *testing.T) {
-	game := NewGame()
 	for i := 0; i < 20; i++ {
-		game.Roll(1)
+		g.Roll(1)
 	}
-	if game.Score() != 20 {
-		t.Errorf("Expected score of 20 but got %d", game.Score())
+
+	if g.Score() != 20 {
+		t.Errorf("Expected score of 20 but got %d", g.Score())
 	}
 }

--- a/kata/bowling_game/go/2023_12-31/bowling_game_test.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game_test.go
@@ -1,0 +1,13 @@
+package bowling
+
+import "testing"
+
+func TestGutterGame(t *testing.T) {
+	game := NewGame()
+	for i := 0; i < 20; i++ {
+		game.Roll(0)
+	}
+	if game.Score() != 0 {
+		t.Errorf("Expected score of 0 but got %d", game.Score())
+	}
+}

--- a/kata/bowling_game/go/2023_12-31/bowling_game_test.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game_test.go
@@ -11,6 +11,12 @@ func setUp() {
 	g = NewGame()
 }
 
+func rollMany(n int, pins int) {
+	for i := 0; i < n; i++ {
+		g.Roll(pins)
+	}
+}
+
 func TestMain(m *testing.M) {
 	setUp()
 
@@ -18,19 +24,14 @@ func TestMain(m *testing.M) {
 }
 
 func TestGutterGame(t *testing.T) {
-	for i := 0; i < 20; i++ {
-		g.Roll(0)
-	}
-
+	rollMany(20, 0)
 	if g.Score() != 0 {
 		t.Errorf("Expected score of 0 but got %d", g.Score())
 	}
 }
 
 func TestAllOnes(t *testing.T) {
-	for i := 0; i < 20; i++ {
-		g.Roll(1)
-	}
+	rollMany(20, 1)
 
 	if g.Score() != 20 {
 		t.Errorf("Expected score of 20 but got %d", g.Score())

--- a/kata/bowling_game/go/2023_12-31/bowling_game_test.go
+++ b/kata/bowling_game/go/2023_12-31/bowling_game_test.go
@@ -11,3 +11,13 @@ func TestGutterGame(t *testing.T) {
 		t.Errorf("Expected score of 0 but got %d", game.Score())
 	}
 }
+
+func TestAllOnes(t *testing.T) {
+	game := NewGame()
+	for i := 0; i < 20; i++ {
+		game.Roll(1)
+	}
+	if game.Score() != 20 {
+		t.Errorf("Expected score of 20 but got %d", game.Score())
+	}
+}

--- a/kata/bowling_game/go/2023_12-31/go.mod
+++ b/kata/bowling_game/go/2023_12-31/go.mod
@@ -1,0 +1,3 @@
+module bowling
+
+go 1.21.5


### PR DESCRIPTION
- goで始めた
- go.modとgo.sumはgit管理する
- 各ロールで一本ずつ倒したときのテスト
- 倒したピンを得点にするように
- setup関数を使うように
- ループ処理をヘルパ関数に切り出した
- TestMainでのsetupはbeforeAll的な挙動だからやめる
- 得点計算処理の修正とスペアのテストを追加
- refactor
- strikenのテストを追加
- strikeの得点計算処理を追加
- refactor
- 完全試合のテストを追加
